### PR TITLE
Adapt dump-submission-to-dashboard to support Inference v0.7

### DIFF
--- a/program/dump-submissions-to-dashboard/.cm/meta.json
+++ b/program/dump-submissions-to-dashboard/.cm/meta.json
@@ -27,7 +27,7 @@
     "default": {
       "ignore_return_code": "no",
       "run_time": {
-        "run_cmd_main": "$<<CK_PYTHON_IPYTHON_BIN_FULL>>$ ..$#dir_sep#$run.py",
+        "run_cmd_main": "$<<CK_PYTHON>>$ ..$#dir_sep#$run.py",
         "run_cmd_out1": "stdout.log",
         "run_cmd_out2": "stderr.log",
         "run_output_files": [

--- a/program/dump-submissions-to-dashboard/run.py
+++ b/program/dump-submissions-to-dashboard/run.py
@@ -549,8 +549,10 @@ def get_data(results_path=results_path, mode='spreadsheet'):
                             results_json_path = os.path.join(accuracy_dir, 'results.json')
                             if os.path.exists(results_json_path):
                                 with open(results_json_path, 'r') as results_file:
-                                    parsed_results = json.load(results_file)
-                                    accuracy = parsed_results.get(f'TestScenario.{scenario_str}', {}).get('accuracy', 0.0)
+                                    results_file_txt = results_file.read().strip()
+                                    if results_file_txt:
+                                        parsed_results = json.loads(results_file_txt)
+                                        accuracy = parsed_results.get(f'TestScenario.{scenario_str}', {}).get('accuracy', 0.0)
                             # if failed, try to load it from accuracy.txt
                             if not accuracy:
                                 accuracy_path = os.path.join(accuracy_dir, 'accuracy.txt')

--- a/program/dump-submissions-to-dashboard/run.py
+++ b/program/dump-submissions-to-dashboard/run.py
@@ -553,6 +553,7 @@ def get_data(results_path=results_path, mode='spreadsheet'):
                                     if results_file_txt:
                                         parsed_results = json.loads(results_file_txt)
                                         accuracy = parsed_results.get(f'TestScenario.{scenario_str}', {}).get('accuracy', 0.0)
+                                        task = 'IC'
                             # if failed, try to load it from accuracy.txt
                             if not accuracy:
                                 accuracy_path = os.path.join(accuracy_dir, 'accuracy.txt')


### PR DESCRIPTION
Hi,

This PR changes `dump-submission-to-dashboard` so that it can work with https://github.com/dividiti/inference_results_v0.7 .

After applying this PR, `dump-submission-to-dashboard` can be run on the 0.7 data to generate a zip file, which then can be used for displaying on the dashboard. 

There are some shortcomings, because I didn't know some facts about the systems:

1. All new systems are set to all four existing filters (Mobile/Handheld, Edge/Embedded, Desktop/Workstation and Server/Cloud). I'm not sure what the appropriate filters are for each case :( 
2. The program sets 'task' depending on accuracy output format (which seems strange for me). There are new accuracy output formats in v0.7. I don't know what the appropriate task is for each of them, so, I just set task = IC.
3. v0.7 has more results, which makes the dashboard loading considerably slower (especially, if we combine 0.5 and 0.7 results). Probably, we should make some performance improvements to the dashboard.

This update should not break compatibility with 0.5, i.e. the program still generates data for 0.5 as well.